### PR TITLE
Fix getPathWithIdentifier for Alerts

### DIFF
--- a/lib/restApi.js
+++ b/lib/restApi.js
@@ -65,7 +65,7 @@ function getPathWithIdentifier(path, params, actionPath) {
         pathParams = params;
     }
 
-    return params ? (path + pathParams + actionPath) : (path);
+    return params ? (path + pathParams) : (path);
 }
 
 exports.getPath = function (path, params, actionPath) {


### PR DESCRIPTION
The current implementation of the function `getPathWithIdentifier` duplicates
the action path for requests that have it defined.

Example:

A request for closing an alert ended up with the following path:
```
/v2/alerts/2c51d1209c682af3c03552683009a7c92535470e/close/?identifierType=alias/close/
```

This would cause the request to fail because the path has an unnecessary extra
token `/close/` in the end.

This commit removes the appending of the `actionPath` in the return clause as it
already happens in the case where `params` is not a string.

I didn't test this change for other use cases than the alert closing, as we
don't have a unit test suite.